### PR TITLE
Catch a few Exceptions, set title for all paths

### DIFF
--- a/SlimFileManager/src/main/java/com/slim/slimfilemanager/fragment/BaseBrowserFragment.java
+++ b/SlimFileManager/src/main/java/com/slim/slimfilemanager/fragment/BaseBrowserFragment.java
@@ -386,10 +386,9 @@ public abstract class BaseBrowserFragment extends Fragment implements View.OnCli
             mSearchView.setIconified(true);
             return true;
         }
-        if (!mCurrentPath.equals(getRootFolder())) {
-            backPressed();
-            mExitOnBack = false;
-        } else if (mCurrentPath.equals(getRootFolder())) {
+
+
+        if (mCurrentPath.equals(getRootFolder())||mCurrentPath.equals("/")) {
             if (mExitOnBack) {
                 mActivity.finish();
             } else {
@@ -397,6 +396,9 @@ public abstract class BaseBrowserFragment extends Fragment implements View.OnCli
                         Toast.LENGTH_SHORT).show();
                 mExitOnBack = true;
             }
+        } else if (!mCurrentPath.equals(getRootFolder())) {
+            backPressed();
+            mExitOnBack = false;
         } else {
             mExitOnBack = false;
         }

--- a/SlimFileManager/src/main/java/com/slim/slimfilemanager/fragment/BrowserFragment.java
+++ b/SlimFileManager/src/main/java/com/slim/slimfilemanager/fragment/BrowserFragment.java
@@ -59,6 +59,8 @@ public class BrowserFragment extends BaseBrowserFragment {
         } else if (file.getAbsolutePath().equals(
                 Environment.getExternalStorageDirectory().getAbsolutePath())) {
             title = "SDCARD";
+        }else {
+            title = path;
         }
         return title;
     }
@@ -167,7 +169,7 @@ public class BrowserFragment extends BaseBrowserFragment {
         Log.d("DATA=" + Environment.getDataDirectory());
         if (SettingsProvider.getBoolean(mContext, SettingsProvider.KEY_ENABLE_ROOT, false)
                 && RootUtils.isRootAvailable()) {
-            return File.separator;
+            return "/";
         } else {
             return Environment.getExternalStorageDirectory().getAbsolutePath();
         }
@@ -175,7 +177,16 @@ public class BrowserFragment extends BaseBrowserFragment {
 
     @Override
     public void backPressed() {
-        filesChanged(new File(mCurrentPath).getParent());
+        try{
+            if (mCurrentPath.equals("/system")) {
+                filesChanged("/");
+            } else {
+                filesChanged(new File(mCurrentPath).getParentFile().getName());
+            }
+        }
+        catch (Exception e){
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/SlimFileManager/src/main/java/com/slim/slimfilemanager/widget/TabItem.java
+++ b/SlimFileManager/src/main/java/com/slim/slimfilemanager/widget/TabItem.java
@@ -22,7 +22,15 @@ public class TabItem {
     public static TabItem fromString(String s) {
         String[] fields = s.split("<.>");
         String path = fields[0];
-        int id = Integer.parseInt(fields[1]);
+        int id = 0;
+
+        try {
+            id = Integer.parseInt(fields[1]);
+        }
+        catch (ArrayIndexOutOfBoundsException e){
+            e.printStackTrace();
+        }
+
         return new TabItem(path, id);
     }
 


### PR DESCRIPTION
if device is running permissive even if we dont give root access we are able to read
root directories at this point getRootFolder will get you "/system" as root path not "/" Added
a few conditions to handle this situation
https://developer.android.com/reference/android/os/Environment.html

and since "/" is not what getRootFolder returns we needs to handle exit of app when in "/"
in a diffrent way (Dont know if this is proper way to do this )